### PR TITLE
Agregado menu minimo que permite copiar y pegar

### DIFF
--- a/app/electron-runner.js
+++ b/app/electron-runner.js
@@ -4,7 +4,105 @@ const http = require('http');
 const serveStatic = require('serve-static');
 const freeport = require('freeport');
 const path = require('path');
-const {app, BrowserWindow, ipcMain, globalShortcut} = require('electron');
+const {app, BrowserWindow, ipcMain, globalShortcut, Menu} = require('electron');
+
+isMac = process.platform === 'darwin';
+
+const template = [
+  // { role: 'appMenu' }
+  ...(isMac ? [{
+    label: app.getName(),
+    submenu: [
+      { role: 'about',
+        label: 'Acerca de Gobstones' },
+      { type: 'separator' },
+      { role: 'hide',
+        label: 'Ocultar Gobstones' },
+      { role: 'hideothers',
+        label: 'Ocultar otros' },
+      { role: 'unhide',
+        label: 'Mostrar Gobstones' },
+      { type: 'separator' },
+      { role: 'quit',
+        label: 'Salir de Gobstones'}
+    ]
+  }] : [
+    {
+      label: 'Archivo',
+      submenu: [
+        { role: 'quit',
+          label: 'Salir de Gobstones' }
+      ]
+    }
+  ])
+  ,
+  // { role: 'editMenu' }
+  {
+    label: 'Editar',
+    submenu: [
+      { role: 'undo',
+        label: 'Deshacer' },
+      { role: 'redo',
+        label: 'Rehacer' },
+      { type: 'separator' },
+      { role: 'cut',
+        label: 'Cortar' },
+      { role: 'copy',
+        label: 'Copiar' },
+      { role: 'paste',
+        label: 'Pegar' },
+      { type: 'separator' },
+      { role: 'delete',
+        label: 'Borrar' },
+      { type: 'separator' },
+      { role: 'selectAll',
+        label: 'Seleccionar todo'}
+    ]
+  },
+  // { role: 'viewMenu' }
+  {
+    label: 'Vista',
+    submenu: [
+      { role: 'reload',
+        label: 'Recargar'},
+      { role: 'forcereload',
+        label: 'Forzar Recarga'},
+      { role: 'toggledevtools',
+        label: 'Mostrar herramientas de desarrollador'},
+      { type: 'separator' },
+      { role: 'resetzoom',
+        label: 'Tamaño original'},
+      { role: 'zoomin',
+        label: 'Acercar'},
+      { role: 'zoomout',
+        label: 'Alejar'},
+      { type: 'separator' },
+      { role: 'togglefullscreen',
+        label: 'Mostrar en pantalla completa'}
+    ]
+  },
+  // { role: 'windowMenu' }
+  {
+    label: 'Ventana',
+    submenu: [
+      { role: 'minimize',
+        label: 'Minimizar' },
+      { role: 'zoom',
+        label: 'Acercarse'},
+      ...(isMac ? [
+        { type: 'separator' },
+        { role: 'front',
+          label: 'Traer al frente' },
+        { type: 'separator' },
+        { role: 'window',
+          label: 'Ventana'}
+      ] : [
+        { role: 'close',
+          label: 'Cerrar'}
+      ])
+    ]
+  },
+]
 
 
 function start(mode) {
@@ -98,6 +196,8 @@ function start(mode) {
         webSecurity: false
       }
     });
+    const menu = Menu.buildFromTemplate(template)
+    Menu.setApplicationMenu(menu)
     mainWindow.loadURL(serverAddress(port));
     mainWindow.maximize();
     mainWindow.on('closed', () => mainWindow = null);

--- a/app/elements/gobstones-editor/gobstones-editor.html
+++ b/app/elements/gobstones-editor/gobstones-editor.html
@@ -447,6 +447,12 @@
       _shouldShow: function(action) {
         if (!this.toolbox || !this.toolbox.defaultToolbox) return true;
 
+        // Show all if the node "Procedimientos primitivos" is present but empty
+        // to emulate Blocks behavior
+        var defaultToolboxDom = new DOMParser().parseFromString('<xml>' +this.toolbox.defaultToolbox + '</xml>', "application/xml");
+        var elements = defaultToolboxDom.getElementsByName('Procedimientos primitivos')
+        if (elements.length && !elements.childNodes) return true;
+
         const toolboxNames = this.toolbox.defaultToolbox
           .match(/<block type="(.+)"/g)
           .map((it) => it.match(/<block type="(.+)"/)[1]);

--- a/app/elements/main-app/select-mode.html
+++ b/app/elements/main-app/select-mode.html
@@ -73,7 +73,6 @@ l">
 
       <paper-icon-button class="button button-code" on-click="useCode" icon="icons:code" alt="use code"> </paper-icon-button>
 
-      <paper-icon-button class="button button-teacher" on-click="useTeacher" icon="icons:card-membership" alt="use teacher"> </paper-icon-button>
     </div>
   </template>
 

--- a/build/builder.js
+++ b/build/builder.js
@@ -30,7 +30,7 @@ const AVAILABLE_ARCHS = ['x64', 'ia32'];
 const AVAILABLE_PLATFORMS = ['freebsd', 'linux', 'mac', 'win'];
 const AVAILABLE_TARGETS = {
     linux: ['AppImage', 'deb', 'rpm', 'pacman'],
-    mac: ['mac', 'dmg'],
+    mac: ['dir', 'dmg'],
     win: ['nsis', 'portable'],
     freebsd: ['freebsd']
 }
@@ -38,7 +38,7 @@ const AVAILABLE_MODES = ['full', 'code', 'blocks', 'teacher']
 
 // A set of rules to avoid invalid configurations on different platforms
 const EXCLUSSION_RULES = [
-    // 
+    //
     (configs) => {
         // Mac only supports 64 bits architecture, remove 32 bit possibilities
         if (configs.mac) {
@@ -126,14 +126,14 @@ yargs
 yargs.parse(process.argv, (err, argv, out) => {
     if (err) {
         console.log(out)
-        process.exit()  
+        process.exit()
     }
     flags = argv
     })
 
 if (flags.help) {
     yargs.showHelp()
-    process.exit() 
+    process.exit()
 }
 
 // Standarize flags
@@ -168,13 +168,7 @@ if (flags.platform.includes('freebsd')) {
     }
 }
 
-/*
-console.log(flags)
-console.log(perPlatformTarget('win', flags.target, flags.arch))
-console.log(perPlatformTarget('mac', flags.target, flags.arch))
-console.log(perPlatformTarget('linux', flags.target, flags.arch))
-process.exit();
-*/
+
 
 // Custom function for generating the building configuration
 function commercialName(mode) {


### PR DESCRIPTION
Esto arregla un issue en MacOS en donde es imposible copiar y pegar código en Gobstones Sr, pues Cmd+C, Cmd+V no quedan asociados a ningún Shortcut si no hay un menú creado. Tampoco se podía seleccionar todo el texto (Cmd+A), cortar (Cmd+X), u otras funciones básicas de edición de texto.

Este pull request soluciona ese problema proporcionando un menú mínimo.

El Menu no es optimo, pues no soporta internacionalización, y carece de ciertas opciones como Buscar, Buscar y Reemplazar, etc. Pero al menos da un soporte básico en el editor.