### PR TITLE
Avoid Auto Translation

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,7 +9,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<html lang="en">
+<html lang="es" translate="no">
 
 <head>
   <meta charset="utf-8">
@@ -43,6 +43,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <!-- Tile icon for Win8 (144x144) -->
   <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
 
+  <!-- Avoid google translation -->
+  <meta name="google" content="notranslate">
+  
   <!-- Dark theme stylesheet - solo cambia algo cuando la clase de main es night -->
   <link rel="stylesheet" href="styles/dark.css">
 


### PR DESCRIPTION
When using Chrome with the automatic translation featured turned on, weird behaviour occurs both in the board and in the code editor. The simple HTML tags added should request translations services to avoid translating automatically. Also the language has been changed to Spanish, as most of our users are until we come up with a real i18n solution.