### PR TITLE
Trying to fix theme switch bug

### DIFF
--- a/app/elements/left-menu/left-menu.html
+++ b/app/elements/left-menu/left-menu.html
@@ -438,6 +438,8 @@
           } else {
             document.getElementById("ace").setAttribute("theme", "ace/theme/chrome");
             document.getElementById("main").classList.remove("night");
+            document.getElementById("editor").classList.remove("ace_dark");
+            document.getElementById("editor").classList.remove("ace_gruvbox");
           }
         });
       },


### PR DESCRIPTION
Attemping to fix #369  that prevents color scheme switch from dark to light mode, removing the property related to theming from child elements of Ace main component