### PR TITLE
Se carga correctamente el árbol de bloques disponibles

### DIFF
--- a/app/elements/blocks-toolbox-selector/blocks-toolbox-selector.html
+++ b/app/elements/blocks-toolbox-selector/blocks-toolbox-selector.html
@@ -335,10 +335,20 @@
               disabled: this._getDisabledBlocks(this._blocks),
               defaultToolbox: _.trim(this.defaultToolbox) !== "" ? this.defaultToolbox : undefined
             };
+            this._notifySelectedBlocksChanged();
             this._isEditingBlocks = false;
           }, 100);
 
         this.__onBlocksUpdate();
+      },
+
+      /* @faloi:
+      Agregué este método para que el metadata-editor se entere de que cambiaron los
+      bloques seleccionados.
+      https://polymer-library.polymer-project.org/1.0/docs/devguide/events#custom-events
+      */
+      _notifySelectedBlocksChanged() {
+        this.fire('teacherSelectedBlocksChanged', this.blocks);
       },
 
       _getVisibleBlocks(array) {

--- a/app/elements/metadata-editor/metadata-editor.html
+++ b/app/elements/metadata-editor/metadata-editor.html
@@ -237,6 +237,7 @@
 
       _selectedBlocksChanged: function({ detail }) {
         this.metadata.blocks = detail;
+        this._refreshPreviewIfEnabled(this.metadata);
       },
 
       _onMetadataChanged: function({ base }) {
@@ -288,8 +289,14 @@
             }));
           }
 
-          if (this.previewChanges) this._previewChanges(base);
+          this._refreshPreviewIfEnabled(base);
         } catch(e) {}
+      },
+
+      _refreshPreviewIfEnabled(metadata) {
+        if (this.previewChanges) {
+          this._previewChanges(metadata);
+        }
       },
 
       _onPreviewChangesChanged(previewChanges) {

--- a/app/elements/metadata-editor/metadata-editor.html
+++ b/app/elements/metadata-editor/metadata-editor.html
@@ -150,7 +150,8 @@
         <div>[[localize("settings-blocks")]]</div>
       </paper-item>
 
-      <blocks-toolbox-selector default-toolbox="{{defaultToolbox}}" blocks="{{metadata.blocks}}"></blocks-toolbox-selector>
+      <!-- Al pasarlo entre corchetes dobles, la expresión se vuelve a evaluar cuando cambia la metadata -->
+      <blocks-toolbox-selector default-toolbox="{{defaultToolbox}}" blocks="[[metadata.blocks]]"></blocks-toolbox-selector>
     </div>
   </template>
 
@@ -170,7 +171,15 @@
         previewChanges: {
           type: Boolean,
           value: false
-        }
+        },
+      },
+      /* @faloi:
+      Agregué este listener para que el blocks-toolbox-selector avise cuando cambian los
+      bloques seleccionados.
+      Ver https://polymer-library.polymer-project.org/1.0/docs/devguide/events#event-listeners
+      */
+      listeners: {
+        'teacherSelectedBlocksChanged': '_selectedBlocksChanged'
       },
       behaviors: [
         Polymer.BusListenerBehavior,
@@ -226,6 +235,10 @@
         event.target.value = null;
       },
 
+      _selectedBlocksChanged: function({ detail }) {
+        this.metadata.blocks = detail;
+      },
+
       _onMetadataChanged: function({ base }) {
         const FIELDS_OF_EDITION_SECTION = [
           "board.collapse_toolbox",
@@ -243,6 +256,7 @@
         const attireFieldsOn = FIELDS_OF_ATTIRE_SECTION.some((it) => _.get(base, it));
 
         this.defaultToolbox = base.blocks && base.blocks.defaultToolbox;
+        this.notifyPath('metadata.blocks');
 
         try {
           if (!base.board.visible_edition && editionFieldsOn) {


### PR DESCRIPTION
## :dart: Objetivo

Closes #398 

## ⚠️ Dependencias

Mergear primero #406, hacer rebase y luego mergear este. 

## :memo: Comentarios adicionales

De yapa, modifiqué el código de preview para que cuando el/la docente cambia los bloques se refleje automáticamente en el editor.

## :camera_flash: Capturas de pantalla / GIFs

![comandos](https://user-images.githubusercontent.com/1585835/127702676-a222d620-9554-4ea5-af2f-5422289e8d45.gif)
