### PR TITLE
El editor de la consigna ya no hace autofoco

### DIFF
--- a/app/elements/description-editor/description-editor.html
+++ b/app/elements/description-editor/description-editor.html
@@ -35,7 +35,7 @@ Descripción del ejercicio.
         this.async(() => {
           this.simplemde = new SimpleMDE({
             element: this.$$("#markdown-editor"),
-            autofocus: true,
+            autofocus: false,
             spellChecker: false,
             hideIcons: ["side-by-side", "fullscreen", "guide"],
             previewRender: function(plainText) {


### PR DESCRIPTION
## :dart: Objetivo

Closes #405 

## :memo: Comentarios adicionales

El problema era que el editor se inicializa asincrónicamente, y le daba el foco aunque no estuviera activo.
