### PR TITLE
Solo se traen los assets globales si existen

### DIFF
--- a/app/scripts/loaders/remote/gitHubGuideLoader.html
+++ b/app/scripts/loaders/remote/gitHubGuideLoader.html
@@ -32,10 +32,16 @@
       if (!COURSE()) return $.Deferred().reject().promise();
 
       const guides = $.getJSON(`https://raw.githubusercontent.com/${COURSE()}/master/guides.json`);
-      const assets = new GitHubLoader(window.GBS_PROJECT_TYPE, COURSE())
-        .loadDir("assets")
-        .then((assets) => {
-          window.GBS_COURSE_ASSETS = assets;
+
+      const loader = new GitHubLoader(window.GBS_PROJECT_TYPE, COURSE());
+      const assets = loader.hasAssets()
+        .then(result =>
+          result ? loader.loadDir("assets") : {}
+        )
+        .then(assets => {
+          if (Object.keys(assets).length) {
+            window.GBS_COURSE_ASSETS = assets;
+          }
         })
         .catch(() => {});
 

--- a/app/scripts/loaders/remote/gitHubLoader.html
+++ b/app/scripts/loaders/remote/gitHubLoader.html
@@ -50,9 +50,16 @@
       });
     }
 
+    hasAssets() {
+      return this.scanDir('.')
+        .then(
+          entries => entries.some(e => e.name === 'assets' && e.type === 'dir')
+        )
+        .catch(() => false);
+    }
+
     scanDir(path = this.initialPath || ".") {
       const [ username, repoName ] = this.slug.split("/");
-
       return $.get(
         `https://gobstones-activity.herokuapp.com/repo/${username}/${repoName}?path=${path}`
       );


### PR DESCRIPTION
## :dart: Objetivo

Solo traer los `assets` globales si existen.

## :memo: Comentarios adicionales

La implementación que había intentaba traer los assets globales siempre, lo cual terminaba consumiendo un crédito de la API de GitHub por proyecto. Lo modifiqué para aprovechar mejor la caché del activity server.