### PR TITLE
Fix scroll vertical

### DIFF
--- a/app/elements/gobstones-teacher/alert-banner.html
+++ b/app/elements/gobstones-teacher/alert-banner.html
@@ -71,6 +71,14 @@
         opacity: .7;
       }
     </style>
+
+    <iron-localstorage
+      name="{{code}}"
+      value="{{closed}}"
+      on-iron-localstorage-load-empty="initialize"
+      on-iron-localstorage-load="showIfImportant">
+    </iron-localstorage>
+
     <div class$="{{cssClass(level, closed)}}">
       <button on-tap="close" aria-label="Close" class="flash-close" type="button">
         <iron-icon icon="close"></iron-icon>
@@ -103,12 +111,19 @@
       is: "alert-banner",
       behaviors: [Polymer.LocalizationBehavior, Polymer.BusListenerBehavior],
       properties: {
+        code: String,
         title: String,
         message: String,
         level: String,
-        closed: {
-          type: Boolean,
-          value: false
+        closed: Boolean,
+      },
+      initialize() {
+        this.closed = false;
+      },
+      showIfImportant() {
+        // Ignore local storage setting if message is important
+        if (this.isImportant()) {
+          this.closed = false;
         }
       },
       cssClass(level, closed) {
@@ -119,6 +134,9 @@
       },
       icon(level) {
         return LEVELS[level].icon;
+      },
+      isImportant() {
+        return this.level === 'warning' || this.level === 'error';
       }
     });
   </script>

--- a/app/elements/gobstones-teacher/alert-banner.html
+++ b/app/elements/gobstones-teacher/alert-banner.html
@@ -10,6 +10,10 @@
         white-space: normal;
       }
 
+      .closed {
+        display: none;
+      }
+
       .flash-error {
         background-color: #fdebe9;
         border-color: #ff818266;
@@ -45,13 +49,36 @@
       .flash-success iron-icon {
         color: #1e7f37;
       }
+
+      .flash-close {
+        float: right;
+        padding: 16px;
+        margin: -16px;
+        text-align: center;
+        cursor: pointer;
+        background: none;
+        border: 0;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+      }
+
+      .flash-close iron-icon {
+        height: 16px;
+      }
+
+      .flash-close iron-icon:hover {
+        opacity: .7;
+      }
     </style>
-    <div class$="{{cssClass(level)}}">
+    <div class$="{{cssClass(level, closed)}}">
+      <button on-tap="close" aria-label="Close" class="flash-close" type="button">
+        <iron-icon icon="close"></iron-icon>
+      </button>
       <iron-icon icon="{{icon(level)}}"></iron-icon>
       <strong>{{ title }}</strong>
       <div>
         {{ message }}
-        <!-- Botones opcionales -->
       </div>
     </div>
   </template>
@@ -78,10 +105,17 @@
       properties: {
         title: String,
         message: String,
-        level: String
+        level: String,
+        closed: {
+          type: Boolean,
+          value: false
+        }
       },
-      cssClass(level) {
-        return `flash flash-${level}`;
+      cssClass(level, closed) {
+        return closed ? 'closed' : `flash flash-${level}`;
+      },
+      close() {
+        this.closed = true;
       },
       icon(level) {
         return LEVELS[level].icon;

--- a/app/elements/gobstones-teacher/gobstones-teacher.html
+++ b/app/elements/gobstones-teacher/gobstones-teacher.html
@@ -139,6 +139,7 @@
         <div class$="editor {{_teacherLibraryClass(selectedTab)}}">
           <template is="dom-if" if="{{!studentSolutionDirty}}">
             <alert-banner
+              code="define-primitives-here"
               title="Definí aquí las primitivas para tu actividad"
               message="Los procedimientos y funciones que definas podrán ser utilizados por tus estudiantes en sus soluciones."
               level="info"
@@ -146,6 +147,7 @@
           </template>
           <template is="dom-if" if="{{studentSolutionDirty}}">
             <alert-banner
+              code="student-code-changed"
               title="Realizaste cambios en la solución del estudiante"
               message="Si renombrás o eliminás alguna primitiva que está en uso, deberás actualizar manualmente la solución del estudiante."
               level="warning"


### PR DESCRIPTION
## :dart: Objetivo

Closes #444 

## :memo: Comentarios adicionales

El problema era el banner que le explica al docente qué hacer en la biblioteca.

Lo que hice fue permitir cerrarlo, y al hacerlo se recuperan las 5-6 líneas que no se veían.

## :camera_flash: Capturas de pantalla / GIFs

Acá se ve cómo "vuelven" las 5 líneas que faltaban.

![banner-info](https://user-images.githubusercontent.com/1585835/140165290-947c83e3-c1d7-4266-854b-393a3d604df0.gif)

Luego de cerrar el banner de info, no se muestra nunca más. El de warning sí se muestra cada vez que aparece, aunque también es posible cerrarlo.

![banner-alert](https://user-images.githubusercontent.com/1585835/140165301-e701b631-8db9-4760-99ee-c356773dbae0.gif)

