### PR TITLE
Se modifica el nombre de vestimenta duplicada

### DIFF
--- a/app/elements/boards-panel/boards-panel.html
+++ b/app/elements/boards-panel/boards-panel.html
@@ -590,8 +590,14 @@
         this.showAttire = !this.showAttire;
       },
 
-      addOrSetAttire: function(attire) {
-        if (this.setAttire(attire.name)) return;
+      addOrSetAttire(attire, { fromLoader = false } = {}) {
+        if (this.setAttire(attire.name)) {
+          if (fromLoader) {
+            attire.name = this._makeDuplicatedName(attire.name);
+          } else {
+            return;
+          }
+        }
 
         this.push("availableAttires", attire);
         this.selectedAttire = -1;
@@ -714,6 +720,22 @@
       toggleToolbox: function(value) {
         this.isToolboxVisible = _.isBoolean(value) ? value : !this.isToolboxVisible;
         this._updateStylistToolboxVisible();
+      },
+
+      _makeDuplicatedName(name) {
+        let duplicatedCount = 1;
+        let newName = `${name} (${duplicatedCount})`;
+
+        while (this._attireExists(newName)) {
+          duplicatedCount++;
+          newName = `${name} (${duplicatedCount})`
+        }
+
+        return newName;
+      },
+
+      _attireExists(name) {
+        return _.some(this.availableAttires, { name });
       },
 
       _bootstrap: function(sizeX = this.sizeX, sizeY = this.sizeY) {

--- a/app/scripts/loaders/components/attires/attireReader.html
+++ b/app/scripts/loaders/components/attires/attireReader.html
@@ -74,7 +74,7 @@
 
     _setAttire(context, attire) {
       if (attire && attire.name && attire.rules)
-        context.boards.addOrSetAttire(attire);
+        context.boards.addOrSetAttire(attire, { fromLoader: true });
     }
 
     _serialize(attire) {


### PR DESCRIPTION
## :dart: Objetivo

Closes #437 

## :memo: Comentarios adicionales

Finalmente hice que le agregue al final un número - al estilo de Windows. Este número se incrementa en 1 cada vez que se agrega otra vestimenta con el mismo nombre.

## :camera_flash: Capturas de pantalla / GIFs

Acá se ve cómo cargo una y otra vez la misma vestimenta y le va cambiando el número:

![vestimentas](https://user-images.githubusercontent.com/1585835/143622429-6ef78478-2ede-4b38-a9ad-a901870082c3.gif)
