### PR TITLE
Results window fixes

### DIFF
--- a/app/elements/boards-panel/boards-panel.html
+++ b/app/elements/boards-panel/boards-panel.html
@@ -173,6 +173,7 @@
         position: fixed;
         bottom: 10px;
         right: 10px;
+        z-index: 100;
       }
 
       paper-tab {
@@ -359,7 +360,7 @@
                   <gs-board id="finalStateEditor" attire="{{attire}}"></gs-board>
 
                   <template is="dom-if" if="{{_hasReturnValue(returnValue)}}">
-                    <paper-button id="inspect-results-button" class="inspect-results-button" style="z-index: 99" on-click="showReturnValue"><iron-icon class="black-button" icon="icons:search"></iron-icon></paper-button>
+                    <paper-button id="inspect-results-button" class="inspect-results-button" on-click="showReturnValue"><iron-icon class="black-button" icon="icons:search"></iron-icon></paper-button>
                     <paper-tooltip for="inspect-results-button" position="left" animation-config="{{tooltipAnimation}}">
                       <div class="button-tooltip">
                         [[localize("tooltip-inspect-results")]]

--- a/app/styles/dark.css
+++ b/app/styles/dark.css
@@ -1,6 +1,5 @@
 /* EDITOR */
-
-#main.night .ace_content{
+#main.night .ace_content, #main.night .inspect-results-modal{
 	background: #2E2E2E !important;
 }
 
@@ -21,7 +20,7 @@
 	color: #FFFFFF !important;
 }
 
-#main.night .ace-tm .ace_cursor {
+#main.night .ace-tm .ace_cursor, #main.night .return-monospace.results-inspector{
      color: white !important; 
 }
 


### PR DESCRIPTION
## :dart: Objetivo

Arregle 2 boludeces que me molestaban:

- Boludez 1: La ventana que mostraba los resultados retornados por la funcion "program" no era compatible con el modo oscuro (parte del texto era invisible y el fondo era blanco). Ahora se ve bien (Ver imagenes al final).

- Boludez 2: El boton de mostrar resultados no era completamente clickeable, solo podias clickear el bordesito. Ahora es completamente clickeable (Ver imagenes al final).

## :camera_flash: Capturas de pantalla / GIFs
### Pantalla de resultados - Antes y Despues
![2022-10-07 01_57_01-curso-InPr-UNQ - Gobstones Web - Opera](https://user-images.githubusercontent.com/82421021/194471275-50d94c39-5b4f-4be9-94e6-37f6fa4da8d8.png)
![2022-10-07 01_56_49-Gobstones Web - Opera](https://user-images.githubusercontent.com/82421021/194471272-a55e6a52-1386-4533-b035-7a72a0c3060a.png)
### Boton de mostrar resultados - Antes y Despues
![2022-10-07 01_53_21-Window](https://user-images.githubusercontent.com/82421021/194471447-c101c9e2-e4fe-4cbd-8a3f-4fee7b3a9bc1.png)
![2022-10-07 01_54_13-Window](https://user-images.githubusercontent.com/82421021/194471448-2b96c16e-b1df-4b22-b68c-f5dd5a997765.png)
